### PR TITLE
Added Weekly Sliver Thread posting

### DIFF
--- a/RedditBotCore/RedditSilverRobot.py
+++ b/RedditBotCore/RedditSilverRobot.py
@@ -3,6 +3,7 @@
 import praw
 import pickle
 import time
+from datetime import datetime, timezone, timedelta, date
 from Structures.Queue import Queue
 
 
@@ -14,6 +15,7 @@ rsr = praw.Reddit(client_id='client_id',
 
 file = 'RSRQueue.p'
 command = '!redditsilver'
+pacific = timezone(timedelta(hours=time.daylight-8))
 
 def validate_comment(comment):
     # Decides whether or not to reply to a given comment.
@@ -58,7 +60,7 @@ def reply(comment):
 def _register_comment(comment, result):
     # Stores data in a list of tuples
     # (ID, (User, Receiver, Time, Result))
-    tup = (comment.id, (comment.author.name, get_receiver(comment), time.localtime(), result))
+    tup = (comment.id, (comment.author.name, get_receiver(comment), datetime.now(tz=pacific), result))
     data = pickle.load(open("RSRData.p", 'rb'))
     if data:
         data.append(tup)
@@ -128,7 +130,62 @@ def _make_message(comment):
     message += comment.author.name + ") "
     message += "__[info](http://reddit.com/r/RedditSilverRobot)__"
     return message
+def get_week_year(date_time=None):
+    # Return a tuple of the week and year of the date_time, 
+    # takes the current time if none is provided a new week 
+    # starts Monday at Midnight Pacific Time (Reddit's time)
 
+    if date_time is None:
+        date_time = datetime.now(tz=timezone(pacific))
+    return (int(date_time.strftime('%W')), date_time.year)
+
+def weekly_post(week, year):
+    # Creates a new post in /r/RedditSilverRobot with 
+    # the highest RedditSilver count for the past week
+    top = 5
+    top_receivers = _highest_weekly_slivers(week, year, top)
+
+    # Why is no one giving any sliver :(
+    if not top_receivers:
+        return
+    message = _make_post_message(top_receivers)
+def _highest_weekly_slivers(week, year, top):
+    # For all enteries made within the last week, count them by the receiver 
+    data_entries = pickle.load(open('RSRData.p', 'rb'))
+        return []
+    counter = dict()
+    for entry in data_entries:
+        week_year = get_week_year(entry[1][2])
+        # Be sure to include the week 0 of the new 
+        # year with the last week of the previous year
+        if week_year == (week, year) or (week_year == (0, year+1)):
+            receiver = entry[1][1]
+            if receiver in counter:
+                counter[receiver] += 1
+            else:
+                counter[receiver] = 1
+def _make_post_message(top_receivers):
+    message += "Welcome to the weekly Reddit Sliver thread! \n***\n"
+    message += "Here we give recongition to the redditors who have "
+    message += "Obtained the most sliver in the past week!"
+    message += "Here are you top earning Reddit Sliver receivers: \n***\n"
+
+    placements = ['1st', '2nd', '3rd', '4th', '5th']
+    for i in range(5):
+        receiver = top_receivers[i]
+        if receiver:
+            message += placements[i] + " place: /u/" + receiver[0] 
+            message += " with a count of " + str(receiver[1]) + " sliver!\n"
+
+    message += "Make sure you're a kind stranger if you want to get Reddit Silver!"
+    return message
+def _post_thread(message):
+    timestr = str(time.localtime()[3]) + ":" + str(time.localtime()[4])
+    try:
+        rsr.subreddit("RedditSilverRobot").submit(date.today().__str__(), selftext=message, send_replies=False)
+        print("> %s - Posted Weekly Thread -> /r/RedditSilverRobot" % timestr )
+    except Exception as post_exception:
+        print("> %s - Unable to post Weekly Thread: %s -> /r/RedditSilverRobot" % (timestr, str(post_exception)))
 if __name__ == '__main__':
 
     try:
@@ -160,3 +217,6 @@ if __name__ == '__main__':
             comment_id = queue.dequeue()
             pickle.dump(queue, open(file, 'wb'))
             reply(praw.models.Comment(rsr, comment_id))
+        # The first Monday in the new year has a week 1 and the 
+        # days between the new year and first Monday have a week 0
+            start_week, start_year = current_week, current_year


### PR DESCRIPTION
WARNING: These changes are untested, I do not have the specific hardware
(Raspberry Pi I assume) that @rudypikulik uses to run the bot. Therefore
I am unable to properly test this.

I have created a feature that makes the bot post a new thread at the
beginning of the week (Monday at midnight, Pacific/Reddit Time). This
thread posts the five redditors who've receivced the most sliver in the
past week.