### PR TITLE
Fixed Contains-function

### DIFF
--- a/RedditBotCore/Structures/Stack.py
+++ b/RedditBotCore/Structures/Stack.py
@@ -32,7 +32,7 @@ class Stack:
     def contains(self, x):
         node = self.front
         while node is not None:
-            if node.get_data() is x:
+            if node.get_data() == x:
                 return True
             node = node.get_next()
         return False


### PR DESCRIPTION
Using the is statement makes the contains()-function never return True, as it's not able to compare two strings. 

> is compares two objects in memory, == compares their values.